### PR TITLE
chore: Use the repository instead of the homepage field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = "CLI management tool for modded Minecraft servers"
 version = "0.4.1"
 edition = "2021"
 authors = ["mxxntype <59417007+mxxntype@users.noreply.github.com>"]
-homepage = "https://github.com/exoumoon/invar"
+repository = "https://github.com/exoumoon/invar"
 license-file = "LICENSE"
 
 [[bin]]


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.